### PR TITLE
Fix apostrophe catastrophe

### DIFF
--- a/overrides/main.html
+++ b/overrides/main.html
@@ -5,6 +5,7 @@ This lesson is under active development and considered pre-alpha.
 {% endblock %}
 
 {% block site_meta %}
+{{ super() }}
 <script type="application/ld+json">
   {
     "@context": "https://schema.org/",


### PR DESCRIPTION
Fix apostrophes and various other symbols rendering incorrectly such as becoming `â€™`. Fixes #26.