### PR TITLE
Create .zenodo.json

### DIFF
--- a/.zenodo.json
+++ b/.zenodo.json
@@ -1,0 +1,1 @@
+#this file is empty by default - please see https://elixir-europe-training.github.io/ELIXIR-TrP-LessonTemplateInstructions-MkDocs/ for instructions 


### PR DESCRIPTION
Adding an empty .zenodo.json file to facilitate issuing DOIs for lessons based on the template via zenodo-GitHub integration.

By leaving it empty it will not override the CITATION.cff file 